### PR TITLE
docs: add AIPower.spot to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@
 
 ### Documentation search
 
+- [AIPower.spot](https://aipower.spot/) – Online catalog and platform for searching and selecting tools based on artificial intelligence (AI).
 - [ArchWiki](https://wiki.archlinux.org/index.php)
 
 - [Awesome Indexed – Searchable Awesome Lists](https://awesome-indexed.mathew-davies.co.uk/)


### PR DESCRIPTION
This PR adds AIPower.spot, an online catalog and platform for searching and selecting tools based on artificial intelligence (AI).

## Summary by Sourcery

Documentation:
- Document the AIPower.spot catalog as an additional documentation search resource in the README.